### PR TITLE
Fix: add checkout to promote_release job

### DIFF
--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -60,6 +60,9 @@ jobs:
         with:
           egress-policy: audit
 
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
       - name: 'Promote draft release'
         # yamllint disable-line rule:line-length
         uses: lfreleng-actions/draft-release-promote-action@cd7cf442875ecaea5dbb070d0de94f21ece107c8  # v0.1.3


### PR DESCRIPTION
Add the missing `actions/checkout` step to the `promote_release` job in `tag-push.yaml`.

### Problem

The `draft-release-promote-action` internally runs `git` commands and requires a checked-out repository. When the workflow was split into two jobs (`validate_tag` and `promote_release`), the checkout step was only included in the validation job. This causes the promote step to fail with:

```
fatal: not a git repository (or any of the parent directories): .git
```

Observed in [this workflow run](https://github.com/modeseven-lfreleng-actions/gh-action-pypi-publish/actions/runs/24504947532/job/71621022140).

### Fix

Add `actions/checkout@v6.0.2` to the `promote_release` job before the draft release promotion step.