### PR TITLE
Fix: harden checkout credential handling

### DIFF
--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -33,6 +33,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: 'Verify pushed tag'
         id: tag_validate
@@ -62,6 +64,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: 'Promote draft release'
         # yamllint disable-line rule:line-length


### PR DESCRIPTION
Set `persist-credentials: false` on both `actions/checkout` steps in `tag-push.yaml` to reduce `GITHUB_TOKEN` exposure.

### Rationale

`actions/checkout` defaults to `persist-credentials: true`, which writes the scoped `GITHUB_TOKEN` into the repo's git config. Neither downstream action (`tag-validate-action`, `draft-release-promote-action`) needs authenticated git operations — both receive tokens via explicit `token` inputs.

This is especially important in the `promote_release` job which has `contents: write` permissions.

### Changes

- Add `persist-credentials: false` to the `validate_tag` checkout step
- Add `persist-credentials: false` to the `promote_release` checkout step

Syncs `tag-push.yaml` with the upstream [actions-template](https://github.com/lfreleng-actions/actions-template) repo (PR lfreleng-actions/actions-template#152).

Addresses Copilot feedback from lfreleng-actions/checkout-gerrit-change-action#84.